### PR TITLE
feat: support annotations

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -64,7 +64,7 @@ jobs:
           id: windows
     steps:
     - name: Get Cached Artifacts
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: dist
         key: dist-${{ github.run_id }}

--- a/.github/workflows/sec-codeql.yml
+++ b/.github/workflows/sec-codeql.yml
@@ -28,7 +28,7 @@ jobs:
         go-version-file: go.mod
         cache: false
     - name: Setup Golang Caches
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
           ~/.cache/go-build

--- a/.github/workflows/tpl-packaging.yml
+++ b/.github/workflows/tpl-packaging.yml
@@ -44,7 +44,7 @@ jobs:
         go-version-file: go.mod
         cache: false
     - name: Setup Golang Caches
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
           ~/.cache/go-build
@@ -88,7 +88,7 @@ jobs:
           docker push ${docker_image_dst}
         done
     - name: Cache Artifacts
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       if: ${{ inputs.artifacts-cache }}
       with:
         path: "${{ inputs.artifacts-cache-path }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/DevOpsHiveHQ/kustomize-plugin-merger
-  govet:
-    check-shadowing: true
   misspell:
     locale: US
   nolintlint:
@@ -25,7 +23,6 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gochecknoinits
     - gocritic
@@ -58,5 +55,9 @@ issues:
   # https://golangci-lint.run/usage/false-positives/#default-exclusions
   exclude-use-default: false
   exclude:
-  - "package-comments: .+"
-  - "ST1000: package comment should be of the form"
+    - "package-comments: .+"
+    - "ST1000: package comment should be of the form"
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ spec:
     output:
       # Available options: raw,configmap,secret
       format: raw
+      #optional, add your custom annotations to a configmap or secret output
+      #annotations:
+      #  kustomize.config.k8s.io/needs-hash: "true"
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,9 @@ spec:
     output:
       # Available options: raw,configmap,secret
       format: raw
-      #optional, add your custom annotations to a configmap or secret output
-      #annotations:
-      #  kustomize.config.k8s.io/needs-hash: "true"
-
+      # Optional: Add custom annotations to output manifest.
+      annotations:
+        app.kubernetes.io/created-by: "kustomize-merger"
 ```
 
 

--- a/pkg/merger/merge.go
+++ b/pkg/merger/merge.go
@@ -85,8 +85,9 @@ func (r *mergerResource) export() []*yaml.RNode {
 		rNode, err := yaml.FromMap(map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
-			"metadata": map[string]string{
-				"name": r.Name,
+			"metadata": map[string]interface{}{
+				"name":        r.Name,
+				"annotations": r.Output.Annotations,
 			},
 		})
 		if err != nil {
@@ -101,8 +102,9 @@ func (r *mergerResource) export() []*yaml.RNode {
 		rNode, err := yaml.FromMap(map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "Secret",
-			"metadata": map[string]string{
-				"name": r.Name,
+			"metadata": map[string]interface{}{
+				"name":        r.Name,
+				"annotations": r.Output.Annotations,
 			},
 		})
 		if err != nil {

--- a/pkg/merger/merge_test.go
+++ b/pkg/merger/merge_test.go
@@ -431,6 +431,32 @@ func TestOutputConfigMap(t *testing.T) {
 				{"src01.3", "prom.yaml", "evaluation_interval", ""},
 			},
 		},
+		{
+			name: "Test ConfigMap output with overlay+annotations",
+			desc: "The number of the outputs in 'ConfigMap+overlay' should be the same as input sources",
+			actual: mergerResource{
+				Name: "test-output-configmap",
+				Output: resourceOutput{
+					Format: "configmap",
+					Annotations: map[string]string{
+						"kustomize.config.k8s.io/needs-hash": "true",
+					},
+					items: map[string]string{
+						"prom.yaml": `
+							global:
+								scrape_interval: 15s
+								evaluation_interval: 15s
+						`,
+					},
+				},
+			},
+			expected: []testMergeCase{
+				{"src01.1", "prom.yaml", "kind: ConfigMap", ""},
+				{"src01.2", "prom.yaml", "name: test-output-configmap", ""},
+				{"src01.3", "prom.yaml", "evaluation_interval", ""},
+				{"src01.4", "prom.yaml", "kustomize.config.k8s.io/needs-hash: \"true\"", ""},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -476,6 +502,32 @@ func TestOutputSecret(t *testing.T) {
 				{"src01.2", "prom.yaml", "kind: Secret", ""},
 				{"src01.2", "prom.yaml", "name: test-output-secret", ""},
 				{"src01.3", "prom.yaml", "CgkJCQkJCQlnbG9iYWw6CgkJCQkJCQkJc2NyYXBlX2ludGVydmFsOiAxNXMKCQkJCQkJCQ", ""},
+			},
+		},
+		{
+			name: "Test Secret output with overlay+annotations",
+			desc: "The number of the outputs in 'Secret+overlay' should be the same as input sources",
+			actual: mergerResource{
+				Name: "test-output-secret",
+				Output: resourceOutput{
+					Format: "secret",
+					Annotations: map[string]string{
+						"kustomize.config.k8s.io/needs-hash": "false",
+					},
+					items: map[string]string{
+						"prom.yaml": `
+							global:
+								scrape_interval: 15s
+								evaluation_interval: 15s
+						`,
+					},
+				},
+			},
+			expected: []testMergeCase{
+				{"src01.2", "prom.yaml", "kind: Secret", ""},
+				{"src01.2", "prom.yaml", "name: test-output-secret", ""},
+				{"src01.3", "prom.yaml", "CgkJCQkJCQlnbG9iYWw6CgkJCQkJCQkJc2NyYXBlX2ludGVydmFsOiAxNXMKCQkJCQkJCQ", ""},
+				{"src01.4", "prom.yaml", "kustomize.config.k8s.io/needs-hash: \"false\"", ""},
 			},
 		},
 	}

--- a/pkg/merger/types.go
+++ b/pkg/merger/types.go
@@ -106,6 +106,7 @@ const (
 )
 
 type resourceOutput struct {
-	Format resourceOutputFormat `yaml:"format" json:"format"`
-	items  map[string]string
+	Format      resourceOutputFormat `yaml:"format" json:"format"`
+	items       map[string]string
+	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }


### PR DESCRIPTION
Add support for custom annotations to the outputted configmap and secret manifests. We have a use case for needing to use the suffix hash generator and options for argocd, like so:

>     output:
>       annotations:
>         kustomize.config.k8s.io/needs-hash: "true"
>         argocd.argoproj.io/sync-options: PruneLast=true
>       format: configmap

Definitely not a go developer though, so welcome any feedback. This works well when I built it locally. 